### PR TITLE
feat: 댓글 개수를 저장하는 로직 구현

### DIFF
--- a/src/main/java/com/isack/syp/article/domain/Article.java
+++ b/src/main/java/com/isack/syp/article/domain/Article.java
@@ -24,7 +24,7 @@ public class Article extends AuditingFields {
 
     private String content;
 
-    private Integer commentsCount;
+    private Integer commentCount;
 
     private Boolean deleted = Boolean.FALSE;
 
@@ -46,6 +46,10 @@ public class Article extends AuditingFields {
 
     public void updateContent(String content) {
         this.content = content;
+    }
+
+    public void addCommentCount() {
+        this.commentCount++;
     }
 
     public boolean isAuthor(Long memberId) {

--- a/src/main/java/com/isack/syp/article/dto/ArticleDto.java
+++ b/src/main/java/com/isack/syp/article/dto/ArticleDto.java
@@ -44,7 +44,7 @@ public class ArticleDto {
                 article.getContent(),
                 article.getCreatedAt(),
                 article.getCreatedBy(),
-                article.getCommentsCount()
+                article.getCommentCount()
         );
     }
 }

--- a/src/main/java/com/isack/syp/comment/service/CommentService.java
+++ b/src/main/java/com/isack/syp/comment/service/CommentService.java
@@ -31,6 +31,7 @@ public class CommentService {
     public Long saveComment(Long articleId, MemberDto memberDto, CommentDto commentDto) {
         Article article = articleRepository.findById(articleId).orElseThrow(IllegalArgumentException::new);
         Member member = memberRepository.findById(memberDto.getId()).orElseThrow(IllegalArgumentException::new);
+        article.addCommentCount(); // TODO: 동시성 고려할 것
         return commentRepository.save(commentDto.toEntity(article, member)).getId();
     }
 


### PR DESCRIPTION
# 작업 내용
* 게시글을 조회할 때마다 count 쿼리를 날리는 것이 부담된다고 판단돼서 댓글을 저장할 때 게시글 테이블의 댓글 개수를 1씩 증가하도록 했습니다.

# 관련 이슈
* This closes #32