### PR TITLE
feat: 로그인 구현

### DIFF
--- a/src/main/java/com/isack/syp/config/SecurityConfig.java
+++ b/src/main/java/com/isack/syp/config/SecurityConfig.java
@@ -22,10 +22,11 @@ public class SecurityConfig {
                         .mvcMatchers(
                                 HttpMethod.GET,
                                 "/",
+                                "/api/articles",
                                 "/api/articles/{}"
                         ).permitAll()
                         .mvcMatchers(HttpMethod.POST,
-                                "/users/form")
+                                "/api/members")
                         .permitAll()
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/isack/syp/member/controller/MemberController.java
+++ b/src/main/java/com/isack/syp/member/controller/MemberController.java
@@ -1,5 +1,6 @@
 package com.isack.syp.member.controller;
 
+import com.isack.syp.member.dto.request.LoginRequest;
 import com.isack.syp.member.dto.request.MemberJoinRequest;
 import com.isack.syp.member.dto.response.MemberResponse;
 import com.isack.syp.member.service.MemberService;
@@ -27,4 +28,5 @@ public class MemberController {
         Long memberId = memberService.createMember(memberJoinRequest.toDto());
         return ResponseEntity.created(URI.create("/api/members/" + memberId)).build();
     }
+
 }

--- a/src/main/java/com/isack/syp/member/domain/Member.java
+++ b/src/main/java/com/isack/syp/member/domain/Member.java
@@ -29,7 +29,7 @@ public class Member {
         this.password = password;
     }
 
-    public static Member of(String loginId, String nickname, String password) {
-        return new Member(loginId, nickname, password);
+    public static Member of(String username, String nickname, String password) {
+        return new Member(username, nickname, password);
     }
 }

--- a/src/main/java/com/isack/syp/member/dto/request/LoginRequest.java
+++ b/src/main/java/com/isack/syp/member/dto/request/LoginRequest.java
@@ -1,0 +1,15 @@
+package com.isack.syp.member.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class LoginRequest {
+
+    private String username;
+    private String password;
+
+    public LoginRequest(String username, String password) {
+        this.username = username;
+        this.password = password;
+    }
+}

--- a/src/main/java/com/isack/syp/member/dto/request/MemberJoinRequest.java
+++ b/src/main/java/com/isack/syp/member/dto/request/MemberJoinRequest.java
@@ -5,17 +5,17 @@ import lombok.Getter;
 
 @Getter
 public class MemberJoinRequest {
-    private String longId;
+    private String username;
     private String nickname;
     private String password;
 
-    public MemberJoinRequest(String longId, String nickname, String password) {
-        this.longId = longId;
+    public MemberJoinRequest(String username, String nickname, String password) {
+        this.username = username;
         this.nickname = nickname;
         this.password = password;
     }
 
     public MemberDto toDto() {
-        return MemberDto.of(longId, nickname, password);
+        return MemberDto.of(username, nickname, password);
     }
 }

--- a/src/main/java/com/isack/syp/member/repository/MemberRepository.java
+++ b/src/main/java/com/isack/syp/member/repository/MemberRepository.java
@@ -6,5 +6,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
+
     Optional<Member> findByNickname(String nickname);
+
+    Optional<Member> findByUsername(String username);
+
+    Optional<Member> findByUsernameAndPassword(String username, String password);
 }

--- a/src/main/java/com/isack/syp/member/service/MemberService.java
+++ b/src/main/java/com/isack/syp/member/service/MemberService.java
@@ -2,6 +2,7 @@ package com.isack.syp.member.service;
 
 import com.isack.syp.member.domain.Member;
 import com.isack.syp.member.dto.MemberDto;
+import com.isack.syp.member.dto.request.LoginRequest;
 import com.isack.syp.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -20,10 +21,15 @@ public class MemberService {
         return memberRepository.findByNickname(nickname).map(MemberDto::from).orElseThrow(IllegalAccessError::new);
     }
 
-
     @Transactional
     public Long createMember(MemberDto memberDto) {
         return memberRepository.save(Member.of(memberDto.getUsername(), memberDto.getNickname(), passwordEncoder.encode(memberDto.getPassword()))).getId();
     }
 
+    public MemberDto login(LoginRequest loginRequest) {
+        String username = loginRequest.getUsername();
+        String password = passwordEncoder.encode(loginRequest.getPassword());
+        Member member = memberRepository.findByUsernameAndPassword(username, password).orElseThrow(IllegalArgumentException::new);//TODO: RuntimeEx을 상속받아서 따로 처리할 것.(LoginFailedException)
+        return MemberDto.from(member);
+    }
 }

--- a/src/main/java/com/isack/syp/member/service/UserDetailsServiceImpl.java
+++ b/src/main/java/com/isack/syp/member/service/UserDetailsServiceImpl.java
@@ -1,0 +1,23 @@
+package com.isack.syp.member.service;
+
+import com.isack.syp.member.dto.MemberDto;
+import com.isack.syp.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class UserDetailsServiceImpl implements UserDetailsService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        return memberRepository.findByUsername(username).map(MemberDto::from).orElseThrow(() -> new UsernameNotFoundException("User not found with username: " + username));
+    }
+}


### PR DESCRIPTION
# 작업 내용
* `SpringSecurity` 의 기본 `formLogin()` 을 사용하는 로그인을 구현하였습니다.
  * `UserDetailsService`를 이용해서 간편하게 구현
 
# 고려할 것
* `formLogin`은 HTML 폼 기반의 로그인 방식을 지원합니다. 그리고 세션 기반 인증이기 때문에 클라이언트의 상태를 서버에 저장하고 유지하는 방식으로 동작합니다. 이러한 방식은 RESTful API에 적합하지 않기에, `JWT`와 같은 토큰 기반의 인증 방식을 고려해야 할 것 같습니다.

# 관련 이슈
This closes #33 