### PR TITLE
feat: 게시글 검색 api 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### Querydsl ###
+/src/main/generated

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,32 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
+
+	// queryDsl 설정
+	implementation "com.querydsl:querydsl-jpa"
+	implementation "com.querydsl:querydsl-core"
+	implementation "com.querydsl:querydsl-collections"
+	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jpa"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+}
+
+// QueryDsl 설정부
+def generated = 'src/main/generated'
+
+// querydsl QClass 파일 생성 위치를 지정
+tasks.withType(JavaCompile) {
+	options.getGeneratedSourceOutputDirectory().set(file(generated))
+}
+
+// java source set 에 querydsl QClass 위치 추가
+sourceSets{
+	main.java.srcDirs += [generated]
+}
+
+// gradle clean 시에 QClass 디렉토리 삭제
+clean{
+	delete file(generated)
 }
 
 tasks.named('bootBuildImage') {

--- a/src/main/java/com/isack/syp/article/controller/ArticleController.java
+++ b/src/main/java/com/isack/syp/article/controller/ArticleController.java
@@ -26,8 +26,10 @@ public class ArticleController {
     private final ArticleService articleService;
 
     @GetMapping
-    public ResponseEntity<ArticlesResponse> findArticles(@PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
-        Page<ArticleResponse> articles = articleService.findAll(pageable).map(ArticleResponse::from);
+    public ResponseEntity<ArticlesResponse> findArticles(
+            @RequestParam(required = false) String articleSearch,
+            @PageableDefault(size = 9, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        Page<ArticleResponse> articles = articleService.findAll(articleSearch, pageable).map(ArticleResponse::from);
         ArticlesResponse articlesResponse = ArticlesResponse.from(articles);
         return ResponseEntity.ok(articlesResponse);
     }

--- a/src/main/java/com/isack/syp/article/dto/ArticleSearch.java
+++ b/src/main/java/com/isack/syp/article/dto/ArticleSearch.java
@@ -1,0 +1,9 @@
+package com.isack.syp.article.dto;
+
+import lombok.Getter;
+
+@Getter
+public class ArticleSearch {
+
+    private String title;
+}

--- a/src/main/java/com/isack/syp/article/repository/ArticleQueryRepository.java
+++ b/src/main/java/com/isack/syp/article/repository/ArticleQueryRepository.java
@@ -1,0 +1,47 @@
+package com.isack.syp.article.repository;
+
+import com.isack.syp.article.domain.Article;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
+
+import javax.persistence.EntityManager;
+import java.util.List;
+
+import static com.isack.syp.article.domain.QArticle.*;
+
+@Repository
+public class ArticleQueryRepository {
+
+    private final JPAQueryFactory query;
+
+    public ArticleQueryRepository(EntityManager em) {
+        this.query = new JPAQueryFactory(em);
+    }
+
+    public Page<Article> findAll(String articleSearch, Pageable pageable) {
+        List<Article> articles = query.select(article)
+                .from(article)
+                .where(likeTitle(articleSearch))
+                .orderBy(article.createdAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long total = query.select(article.count())
+                .from(article)
+                .where(likeTitle(articleSearch))
+                .fetchOne();
+
+        return new PageImpl<>(articles, pageable, total);
+
+    }
+
+    private BooleanExpression likeTitle(String title) {
+        return StringUtils.hasText(title) ? article.title.like("%" + title + "%") : null;
+    }
+}

--- a/src/main/java/com/isack/syp/article/service/ArticleService.java
+++ b/src/main/java/com/isack/syp/article/service/ArticleService.java
@@ -2,6 +2,7 @@ package com.isack.syp.article.service;
 
 import com.isack.syp.article.domain.Article;
 import com.isack.syp.article.dto.ArticleDto;
+import com.isack.syp.article.repository.ArticleQueryRepository;
 import com.isack.syp.article.repository.ArticleRepository;
 import com.isack.syp.member.domain.Member;
 import com.isack.syp.member.dto.MemberDto;
@@ -18,10 +19,15 @@ import org.springframework.transaction.annotation.Transactional;
 public class ArticleService {
 
     private final ArticleRepository articleRepository;
+    private final ArticleQueryRepository articleQueryRepository;
     private final MemberRepository memberRepository;
 
     public Page<ArticleDto> findAll(Pageable pageable) {
         return articleRepository.findAll(pageable).map(ArticleDto::from);
+    }
+
+    public Page<ArticleDto> findAll(String articleSearch, Pageable pageable) {
+        return articleQueryRepository.findAll(articleSearch, pageable).map(ArticleDto::from);
     }
 
     public ArticleDto findById(Long id) {


### PR DESCRIPTION
# 작업 내용
* `Querydsl` 을 이용해서 게시글 제목 검색 api를 구현하였습니다.

# 관련 이슈
* This closes #42 