### PR TITLE
게시글 저장할 때 플레이리스트 저장 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,9 @@ dependencies {
 	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jpa"
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+	implementation platform("org.springframework.cloud:spring-cloud-dependencies:2021.0.5")
+	implementation "org.springframework.cloud:spring-cloud-starter-openfeign"
 }
 
 // QueryDsl 설정부

--- a/src/main/java/com/isack/syp/InitDb.java
+++ b/src/main/java/com/isack/syp/InitDb.java
@@ -3,6 +3,7 @@ package com.isack.syp;
 import com.isack.syp.article.domain.Article;
 import com.isack.syp.comment.domain.Comment;
 import com.isack.syp.member.domain.Member;
+import com.isack.syp.playlist.domain.Playlist;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
@@ -23,13 +24,16 @@ public class InitDb {
 
         int num = 1;
 
+        Playlist playlist = Playlist.of("PLHUkhevQftgHALH-5KjRrGcayDvollcrj", "https://i.ytimg.com/vi/Tw7dU-9AkmU/mqdefault.jpg");
+        em.persist(playlist);
+
         for (int i = 1; i <= 3; i++) {
             Member member = Member.of("member" + i, "memberNickname" + i, "{noop}password123");
             em.persist(member);
 
             //글 생성
             for (int j = 1; j <= 100; j++) {
-                Article article = Article.of(member, "Test title" + num++, "Content is...");
+                Article article = Article.of(member, "Test title" + num++, "Content is...", playlist);
                 article.setCreatedBy(member.getNickname());
                 em.persist(article);
 

--- a/src/main/java/com/isack/syp/SypApplication.java
+++ b/src/main/java/com/isack/syp/SypApplication.java
@@ -2,7 +2,9 @@ package com.isack.syp;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
+@EnableFeignClients
 @SpringBootApplication
 public class SypApplication {
 

--- a/src/main/java/com/isack/syp/article/domain/Article.java
+++ b/src/main/java/com/isack/syp/article/domain/Article.java
@@ -21,7 +21,7 @@ public class Article extends AuditingFields {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_Id")
+    @JoinColumn(name = "member_id")
     private Member member;
 
     private String title;
@@ -30,18 +30,23 @@ public class Article extends AuditingFields {
 
     private Integer commentCount;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "playlist_id")
+    private Playlist playlist;
+
     private Boolean deleted = Boolean.FALSE;
 
     protected Article() {}
 
-    private Article(Member member, String title, String content) {
+    private Article(Member member, String title, String content, Playlist playlist) {
         this.member = member;
         this.title = title;
         this.content = content;
+        this.playlist = playlist;
     }
 
-    public static Article of(Member member, String title, String content){
-        return new Article(member, title, content);
+    public static Article of(Member member, String title, String content, Playlist playlist){
+        return new Article(member, title, content, playlist);
     }
 
     public void updateTitle(String title) {

--- a/src/main/java/com/isack/syp/article/dto/ArticleDto.java
+++ b/src/main/java/com/isack/syp/article/dto/ArticleDto.java
@@ -3,6 +3,8 @@ package com.isack.syp.article.dto;
 import com.isack.syp.article.domain.Article;
 import com.isack.syp.member.domain.Member;
 import com.isack.syp.member.dto.MemberDto;
+import com.isack.syp.playlist.domain.Playlist;
+import com.isack.syp.playlist.dto.PlaylistDto;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
@@ -16,8 +18,9 @@ public class ArticleDto {
     private LocalDateTime createdAt;
     private String createdBy;
     private Integer commentCount;
+    private PlaylistDto playlistDto;
 
-    public ArticleDto(Long id, MemberDto memberDto, String title, String content, LocalDateTime createdAt, String createdBy, Integer commentsCount) {
+    public ArticleDto(Long id, MemberDto memberDto, String title, String content, LocalDateTime createdAt, String createdBy, Integer commentsCount, PlaylistDto playlistDto) {
         this.id = id;
         this.memberDto = memberDto;
         this.title = title;
@@ -25,15 +28,16 @@ public class ArticleDto {
         this.createdAt = createdAt;
         this.createdBy = createdBy;
         this.commentCount = commentsCount;
+        this.playlistDto = playlistDto;
     }
 
-    public static ArticleDto of(MemberDto memberDto, String title, String content) {
-        return new ArticleDto(null, memberDto, title, content, null, null, null);
+    public static ArticleDto of(MemberDto memberDto, String title, String content, PlaylistDto playlistDto) {
+        return new ArticleDto(null, memberDto, title, content, null, null, null, playlistDto);
     }
 
 
-    public Article toEntity(Member member) {
-        return Article.of(member, title, content);
+    public Article toEntity(Member member, Playlist playlist) {
+        return Article.of(member, title, content, playlist);
     }
 
     public static ArticleDto from(Article article) {
@@ -44,7 +48,9 @@ public class ArticleDto {
                 article.getContent(),
                 article.getCreatedAt(),
                 article.getCreatedBy(),
-                article.getCommentCount()
+                article.getCommentCount(),
+                PlaylistDto.from(article.getPlaylist())
         );
     }
+
 }

--- a/src/main/java/com/isack/syp/article/dto/request/ArticleRequest.java
+++ b/src/main/java/com/isack/syp/article/dto/request/ArticleRequest.java
@@ -2,19 +2,23 @@ package com.isack.syp.article.dto.request;
 
 import com.isack.syp.article.dto.ArticleDto;
 import com.isack.syp.member.dto.MemberDto;
+import com.isack.syp.playlist.dto.PlaylistDto;
 import lombok.Getter;
 
 @Getter
 public class ArticleRequest {
     private String title;
     private String content;
+    private String apiId;
 
-    public ArticleRequest(String title, String content) {
+    public ArticleRequest(String title, String content, String apiId) {
         this.title = title;
         this.content = content;
+        this.apiId = apiId;
     }
 
     public ArticleDto toDto(MemberDto memberDto) {
-        return ArticleDto.of(memberDto, title, content);
+        return ArticleDto.of(memberDto, title, content, PlaylistDto.of(apiId));
     }
+
 }

--- a/src/main/java/com/isack/syp/article/dto/request/ArticleUpdateRequest.java
+++ b/src/main/java/com/isack/syp/article/dto/request/ArticleUpdateRequest.java
@@ -2,14 +2,16 @@ package com.isack.syp.article.dto.request;
 
 import com.isack.syp.article.dto.ArticleDto;
 import com.isack.syp.member.dto.MemberDto;
+import com.isack.syp.playlist.dto.PlaylistDto;
 import lombok.Getter;
 
 @Getter
 public class ArticleUpdateRequest {
     private String title;
     private String content;
+    private String apiId;
 
     public ArticleDto toDto(MemberDto memberDto) {
-        return ArticleDto.of(memberDto, title, content);
+        return ArticleDto.of(memberDto, title, content, PlaylistDto.of(apiId));
     }
 }

--- a/src/main/java/com/isack/syp/article/dto/response/ArticleResponse.java
+++ b/src/main/java/com/isack/syp/article/dto/response/ArticleResponse.java
@@ -13,14 +13,18 @@ public class ArticleResponse {
     private String createdBy;
     private LocalDateTime createdAt;
     private Integer commentCount;
+    private String apiId;
+    private String thumbnailUrl;
 
-    public ArticleResponse(Long id, String title, String content, String createdBy, LocalDateTime createdAt, Integer commentCount) {
+    public ArticleResponse(Long id, String title, String content, String createdBy, LocalDateTime createdAt, Integer commentCount, String apiId, String thumbnailUrl) {
         this.id = id;
         this.title = title;
         this.content = content;
         this.createdBy = createdBy;
         this.createdAt = createdAt;
         this.commentCount = commentCount;
+        this.apiId = apiId;
+        this.thumbnailUrl = thumbnailUrl;
     }
 
     public static ArticleResponse from(ArticleDto articleDto) {
@@ -30,7 +34,9 @@ public class ArticleResponse {
                 articleDto.getContent(),
                 articleDto.getCreatedBy(),
                 articleDto.getCreatedAt(),
-                articleDto.getCommentCount()
+                articleDto.getCommentCount(),
+                articleDto.getPlaylistDto().getApiId(),
+                articleDto.getPlaylistDto().getThumbnailUrl()
         );
     }
 }

--- a/src/main/java/com/isack/syp/article/service/ArticleService.java
+++ b/src/main/java/com/isack/syp/article/service/ArticleService.java
@@ -7,6 +7,10 @@ import com.isack.syp.article.repository.ArticleRepository;
 import com.isack.syp.member.domain.Member;
 import com.isack.syp.member.dto.MemberDto;
 import com.isack.syp.member.repository.MemberRepository;
+import com.isack.syp.playlist.domain.Playlist;
+import com.isack.syp.playlist.dto.PlaylistDto;
+import com.isack.syp.playlist.repository.PlaylistRepository;
+import com.isack.syp.playlist.service.PlaylistService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -21,6 +25,7 @@ public class ArticleService {
     private final ArticleRepository articleRepository;
     private final ArticleQueryRepository articleQueryRepository;
     private final MemberRepository memberRepository;
+    private final PlaylistService playlistService;
 
     public Page<ArticleDto> findAll(Pageable pageable) {
         return articleRepository.findAll(pageable).map(ArticleDto::from);
@@ -36,8 +41,13 @@ public class ArticleService {
 
     @Transactional
     public Long saveArticle(ArticleDto articleDto) {
+        if (playlistService.findByApiId(articleDto.getPlaylistDto().getApiId()).isEmpty()) {
+            Playlist playlist = playlistService.savePlaylist(articleDto.getPlaylistDto()); //TODO: 플레이리스트가 중복일 경우 처리
+        }
+
+        Playlist playlist = playlistService.findByApiId(articleDto.getPlaylistDto().getApiId()).get();
         Member member = memberRepository.findById(articleDto.getMemberDto().getId()).orElseThrow(IllegalArgumentException::new);
-        return articleRepository.save(articleDto.toEntity(member)).getId();
+        return articleRepository.save(articleDto.toEntity(member, playlist)).getId();
     }
 
     @Transactional

--- a/src/main/java/com/isack/syp/config/SecurityConfig.java
+++ b/src/main/java/com/isack/syp/config/SecurityConfig.java
@@ -31,7 +31,8 @@ public class SecurityConfig {
                                 "/articles/{}",
                                 "/api/articles",
                                 "/api/articles/{}",
-                                "/api/articles/{}/comments"
+                                "/api/articles/{}/comments",
+                                "/api/playlists"
                         ).permitAll()
                         .mvcMatchers(HttpMethod.POST,
                                 "/api/members")

--- a/src/main/java/com/isack/syp/feign/YoutubeClient.java
+++ b/src/main/java/com/isack/syp/feign/YoutubeClient.java
@@ -1,0 +1,13 @@
+package com.isack.syp.feign;
+
+import com.isack.syp.feign.dto.response.ThumbnailUrlDto;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(name = "youtubeClient", url = "https://www.googleapis.com/youtube/v3")
+public interface YoutubeClient {
+
+    @GetMapping("/playlistItems")
+    ThumbnailUrlDto getThumbnailUrl(@RequestParam String part, @RequestParam int maxResults, @RequestParam String playlistId, @RequestParam String key);
+}

--- a/src/main/java/com/isack/syp/feign/dto/response/ThumbnailUrlDto.java
+++ b/src/main/java/com/isack/syp/feign/dto/response/ThumbnailUrlDto.java
@@ -1,0 +1,30 @@
+package com.isack.syp.feign.dto.response;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class ThumbnailUrlDto {
+    private List<PlaylistItemDto> items;
+
+    @Getter
+    public static class PlaylistItemDto{
+        private SnippetDto snippet;
+
+        @Getter
+        public static class SnippetDto{
+            private ThumbnailsDto thumbnails;
+
+            @Getter
+            public static class ThumbnailsDto{
+                private MediumDto medium;
+
+                @Getter
+                public static class MediumDto{
+                    private String url;
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/isack/syp/playlist/controller/PlaylistController.java
+++ b/src/main/java/com/isack/syp/playlist/controller/PlaylistController.java
@@ -1,0 +1,26 @@
+package com.isack.syp.playlist.controller;
+
+import com.isack.syp.feign.dto.response.ThumbnailUrlDto;
+import com.isack.syp.playlist.service.PlaylistService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/playlists")
+@RestController
+public class PlaylistController {
+
+    @Value("${apiKey}")
+    private String apiKey;
+
+    private final PlaylistService playlistService;
+
+    @GetMapping
+    public ThumbnailUrlDto getPlaylist() {
+        return playlistService.getThumbnailUrl("snippet", 1, "PLHUkhevQftgHALH-5KjRrGcayDvollcrj", apiKey);
+    }
+
+}

--- a/src/main/java/com/isack/syp/playlist/domain/Playlist.java
+++ b/src/main/java/com/isack/syp/playlist/domain/Playlist.java
@@ -1,6 +1,5 @@
 package com.isack.syp.playlist.domain;
 
-import com.isack.syp.article.domain.Article;
 import lombok.Getter;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
@@ -8,8 +7,6 @@ import org.hibernate.annotations.Where;
 import javax.persistence.*;
 
 @Getter
-@SQLDelete(sql = "UPDATE playlist SET deleted = true WHERE id = ?")
-@Where(clause = "deleted = false")
 @Entity
 public class Playlist {
 
@@ -17,11 +14,23 @@ public class Playlist {
     @Id
     private Long id;
 
-    private String playlistId;
+    @Column(unique = true)
+    private String apiId;
 
-    private Boolean deleted = Boolean.FALSE;
+    private String thumbnailUrl;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "article_id")
-    private Article article;
+    private Integer likeCount;
+
+    protected Playlist() {}
+
+    private Playlist(String apiId, String thumbnailUrl) {
+        this.apiId = apiId;
+        this.thumbnailUrl = thumbnailUrl;
+    }
+
+    public static Playlist of(String apiId, String thumbnailUrl) {
+        return new Playlist(apiId, thumbnailUrl);
+    }
+
+
 }

--- a/src/main/java/com/isack/syp/playlist/dto/PlaylistDto.java
+++ b/src/main/java/com/isack/syp/playlist/dto/PlaylistDto.java
@@ -6,14 +6,24 @@ import lombok.Getter;
 @Getter
 public class PlaylistDto {
     private Long id;
-    private String playlistId;
+    private String apiId;
+    private String thumbnailUrl;
 
-    public PlaylistDto(Long id, String playlistId) {
+    public PlaylistDto(Long id, String apiId, String thumbnailUrl) {
         this.id = id;
-        this.playlistId = playlistId;
+        this.apiId = apiId;
+        this.thumbnailUrl = thumbnailUrl;
+    }
+
+    public static PlaylistDto of(String apiId) {
+        return new PlaylistDto(null, apiId, null);
     }
 
     public static PlaylistDto from(Playlist playlist) {
-        return new PlaylistDto(playlist.getId(), playlist.getPlaylistId());
+        return new PlaylistDto(playlist.getId(), playlist.getApiId(), playlist.getThumbnailUrl());
+    }
+
+    public Playlist toEntity(String thumbnailUrl) {
+        return Playlist.of(apiId, thumbnailUrl);
     }
 }

--- a/src/main/java/com/isack/syp/playlist/repository/PlaylistRepository.java
+++ b/src/main/java/com/isack/syp/playlist/repository/PlaylistRepository.java
@@ -1,0 +1,11 @@
+package com.isack.syp.playlist.repository;
+
+import com.isack.syp.playlist.domain.Playlist;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PlaylistRepository extends JpaRepository<Playlist, Long> {
+
+    Optional<Playlist> findByApiId(String apiId);
+}

--- a/src/main/java/com/isack/syp/playlist/service/PlaylistService.java
+++ b/src/main/java/com/isack/syp/playlist/service/PlaylistService.java
@@ -1,0 +1,46 @@
+package com.isack.syp.playlist.service;
+
+import com.isack.syp.feign.YoutubeClient;
+import com.isack.syp.feign.dto.response.ThumbnailUrlDto;
+import com.isack.syp.playlist.repository.PlaylistRepository;
+import com.isack.syp.playlist.domain.Playlist;
+import com.isack.syp.playlist.dto.PlaylistDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class PlaylistService {
+
+    @Value("${apiKey}")
+    private String apiKey;
+
+    private final YoutubeClient youtubeClient;
+    private final PlaylistRepository playlistRepository;
+
+    @Transactional
+    public Playlist savePlaylist(PlaylistDto playlistDto) {
+        ThumbnailUrlDto thumbnailUrlDto = youtubeClient.getThumbnailUrl("snippet", 1, playlistDto.getApiId(), apiKey);
+        String thumbnailUrl = thumbnailUrlDto.getItems().get(0).getSnippet().getThumbnails().getMedium().getUrl();
+        return playlistRepository.save(playlistDto.toEntity(thumbnailUrl));
+    }
+
+    public Optional<Playlist> findByApiId(String apiId) {
+        return playlistRepository.findByApiId(apiId);
+    }
+
+    public PlaylistDto findById(Long id) {
+        return playlistRepository.findById(id).map(PlaylistDto::from).orElseThrow(IllegalArgumentException::new);
+    }
+
+    public ThumbnailUrlDto getThumbnailUrl(String part, int maxResult, String playlistId, String key) {
+        return youtubeClient.getThumbnailUrl(part, maxResult, playlistId, key);
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,3 +12,5 @@ spring:
     show-sql: true
     properties:
       hibernate.format_sql: true
+
+apiKey: ${API_KEY}


### PR DESCRIPTION
# 작업 내용
* 게시글을 저장하는 api 에서 apiId(플레이리스트 ID) 를 받아서 db 의 게시글 테이블과 플레이리스트 테이블에 저장하도록 구현했습니다.
* 저장할 때 우선 db 에서 apiId로 조회 후 존재 안 하면 플레이리스트 테이블에 저장하고 존재하면 그대로 가져와서 게시글 테이블에 저장합니다.
* 플레이리스트의 썸네일이미지 url을 가져오기 위해서 `Open Feign` 의존성을 추가했습니다.
  * `@FeignClient`를 이용해서 `interface YoutubeClient` 를 간단하게 구현했습니다.
    * `https://www.googleapis.com/youtube/v3/playlistItems` 를 호출합니다.
    * 썸네일 url 을 반환하는 `getThumbnailUrl` 에서 part, maxResults, key 를 인자로 받습니다.


# 고려할 것
* 게시글과 플레이리스트의 관계는 N : 1 입니다. 이에 발생하는 1+n 문제를 고려해야합니다.
  * `@EntityGraph` 


# 관련 이슈
* This closes #46 