### PR TITLE
feat: 시큐리티 로그인 JSON 으로 받게하기

### DIFF
--- a/src/main/java/com/isack/syp/config/MemberPrincipal.java
+++ b/src/main/java/com/isack/syp/config/MemberPrincipal.java
@@ -1,0 +1,18 @@
+package com.isack.syp.config;
+
+import com.isack.syp.member.domain.Member;
+import com.isack.syp.member.dto.MemberDto;
+
+public class MemberPrincipal extends MemberDto {
+
+    private final Long memberId;
+
+    public MemberPrincipal(Member member) {
+        super(member.getId(), member.getUsername(), member.getNickname(), member.getPassword());
+        this.memberId = member.getId();
+    }
+
+    public Long getMemberId() {
+        return memberId;
+    }
+}

--- a/src/main/java/com/isack/syp/config/SecurityConfig.java
+++ b/src/main/java/com/isack/syp/config/SecurityConfig.java
@@ -1,19 +1,35 @@
 package com.isack.syp.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.isack.syp.config.filter.LoginAuthFilter;
+import com.isack.syp.config.handler.LoginFailHandler;
+import com.isack.syp.config.handler.LoginSuccessHandler;
+import com.isack.syp.member.repository.MemberRepository;
+import com.isack.syp.member.service.UserDetailsServiceImpl;
+import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.ProviderManager;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
 
 import static org.springframework.security.config.Customizer.withDefaults;
 
 @Configuration
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final ObjectMapper objectMapper;
+    private final MemberRepository memberRepository;
 
     @Bean
     public WebSecurityCustomizer webSecurityCustomizer() {
@@ -39,11 +55,29 @@ public class SecurityConfig {
                         .permitAll()
                         .anyRequest().authenticated()
                 )
-                .formLogin(withDefaults())
+                .addFilterBefore(loginAuthFilter(), UsernamePasswordAuthenticationFilter.class)
                 .logout(logout -> logout.logoutSuccessUrl("/"))
                 .csrf().disable()
                 .cors().and()
                 .build();
+    }
+
+    @Bean
+    public LoginAuthFilter loginAuthFilter() {
+        LoginAuthFilter filter = new LoginAuthFilter("/api/login",objectMapper);
+        filter.setAuthenticationManager(authenticationManager());
+        filter.setAuthenticationSuccessHandler(new LoginSuccessHandler(objectMapper));
+        filter.setAuthenticationFailureHandler(new LoginFailHandler(objectMapper));
+        filter.setSecurityContextRepository(new HttpSessionSecurityContextRepository());
+        return filter;
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager() {
+        DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
+        provider.setUserDetailsService(new UserDetailsServiceImpl(memberRepository));
+        provider.setPasswordEncoder(passwordEncoder());
+        return new ProviderManager(provider);
     }
 
     @Bean

--- a/src/main/java/com/isack/syp/config/filter/LoginAuthFilter.java
+++ b/src/main/java/com/isack/syp/config/filter/LoginAuthFilter.java
@@ -1,0 +1,42 @@
+package com.isack.syp.config.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.Getter;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class LoginAuthFilter extends AbstractAuthenticationProcessingFilter {
+
+    private final ObjectMapper objectMapper;
+
+    public LoginAuthFilter(String loginUrl, ObjectMapper objectMapper) {
+        super(loginUrl);
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException, IOException, ServletException {
+        LoginAuth loginAuth = objectMapper.readValue(request.getInputStream(), LoginAuth.class);
+
+        UsernamePasswordAuthenticationToken token = UsernamePasswordAuthenticationToken.unauthenticated(
+                loginAuth.username, loginAuth.password
+        );
+
+        token.setDetails(this.authenticationDetailsSource.buildDetails(request));
+
+        return this.getAuthenticationManager().authenticate(token);
+    }
+
+    @Getter
+    private static class LoginAuth{
+        private String username;
+        private String password;
+    }
+}

--- a/src/main/java/com/isack/syp/config/handler/LoginFailHandler.java
+++ b/src/main/java/com/isack/syp/config/handler/LoginFailHandler.java
@@ -1,0 +1,38 @@
+package com.isack.syp.config.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.isack.syp.exception.dto.ErrorResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+@Slf4j
+@RequiredArgsConstructor
+public class LoginFailHandler implements AuthenticationFailureHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
+        log.error("[인증오류] 아이디 혹은 비밀번호가 올바르지 않습니다.");
+
+        ErrorResponse errorResponse = ErrorResponse.builder()
+                .code("400")
+                .message("아이디 혹은 비밀번호가 올바르지 않습니다.")
+                .build();
+
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        objectMapper.writeValue(response.getWriter(), errorResponse);
+
+    }
+}

--- a/src/main/java/com/isack/syp/config/handler/LoginSuccessHandler.java
+++ b/src/main/java/com/isack/syp/config/handler/LoginSuccessHandler.java
@@ -1,0 +1,38 @@
+package com.isack.syp.config.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.isack.syp.config.MemberPrincipal;
+import com.isack.syp.member.dto.MemberDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.security.Principal;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static javax.servlet.http.HttpServletResponse.SC_OK;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+@Slf4j
+@RequiredArgsConstructor
+public class LoginSuccessHandler implements AuthenticationSuccessHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request,
+                                        HttpServletResponse response,
+                                        Authentication authentication) throws IOException, ServletException {
+        MemberDto principal = (MemberDto)authentication.getPrincipal();
+        log.info("[인증성공] user={}", principal.getUsername());
+
+        response.setContentType(APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(UTF_8.name());
+        response.setStatus(SC_OK);
+    }
+}

--- a/src/main/java/com/isack/syp/exception/dto/ErrorResponse.java
+++ b/src/main/java/com/isack/syp/exception/dto/ErrorResponse.java
@@ -1,0 +1,25 @@
+package com.isack.syp.exception.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+public class ErrorResponse {
+
+    private final String code;
+    private final String message;
+    private final Map<String, String> validation;
+
+    @Builder
+    public ErrorResponse(String code, String message, Map<String, String> validation) {
+        this.code = code;
+        this.message = message;
+        this.validation = validation;
+    }
+
+    public void addValidation(String fieldName, String errorMessage) {
+        this.validation.put(fieldName, errorMessage);
+    }
+}


### PR DESCRIPTION
# 작업 내용
* 로그인 시 `x-www-form-urlencoded` 형식으로 정보가 들어왔었는데, JSON 형식으로 들어오도록 필터를 구현해서 변경했습니다.

# 작업 상세
* feat: 로그인 성공, 실패시 핸들러 구현
* feat: 필터 구현
  * `AbstactAuthenticationProcessingFilter` 를 확장해서 구현함
  * `attemptAuthentication` 메서드는 HTTP 요청에서 JSON 데이터를 읽어들여 `UsernamePasswordAuthenticationToken`을 생성하고 이를 인증 매니저에게 전달함
  * `LoginAuthFilter` 는 `AuthenticatoinManager` 에게 인증을 위임함. 이는 일반적으로 `ProviderManager`로 구현되며, 등록된 `AuthenticationProvier`를 사용하여 인증을 처리함
    * `DaoAuthenticationProvier` 가 `UserDetailsServiceImpl` 의 `loadUserByUsername` 을 사용하도록 설정함
  * 결과적으로 내가 설정한 `UserDetrailsService` 와 `PasswordEncoder` 를 사용하여 인증을 수행함

# 관련 이슈
* This closes #58 