### PR TITLE
feat: 로그인시 상태저장 구현

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -16,6 +16,7 @@
         "element-plus": "^2.7.3",
         "normalize.css": "^8.0.1",
         "pinia": "^2.1.7",
+        "pinia-plugin-persistedstate": "^3.2.1",
         "reflect-metadata": "^0.2.2",
         "tsyringe": "^4.8.0",
         "vue": "^3.4.21",
@@ -4601,6 +4602,14 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/pinia-plugin-persistedstate": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/pinia-plugin-persistedstate/-/pinia-plugin-persistedstate-3.2.1.tgz",
+      "integrity": "sha512-MK++8LRUsGF7r45PjBFES82ISnPzyO6IZx3CH5vyPseFLZCk1g2kgx6l/nW8pEBKxxd4do0P6bJw+mUSZIEZUQ==",
+      "peerDependencies": {
+        "pinia": "^2.0.0"
       }
     },
     "node_modules/pinia/node_modules/vue-demi": {

--- a/front/package.json
+++ b/front/package.json
@@ -21,6 +21,7 @@
     "element-plus": "^2.7.3",
     "normalize.css": "^8.0.1",
     "pinia": "^2.1.7",
+    "pinia-plugin-persistedstate": "^3.2.1",
     "reflect-metadata": "^0.2.2",
     "tsyringe": "^4.8.0",
     "vue": "^3.4.21",

--- a/front/src/components/Header.vue
+++ b/front/src/components/Header.vue
@@ -2,20 +2,67 @@
   <el-header class="header">
     <!--        <RouterLink to="/">Home</RouterLink>-->
     <!--        <RouterLink to="/write">글작성</RouterLink>-->
-    <el-menu mode="horizontal" router>
-      <el-menu-item index="/">Home</el-menu-item>
-      <el-menu-item index="/write">글작성</el-menu-item>
+    <el-menu mode="horizontal" class="menu-left" :ellipsis="false" router>
+      <el-menu-item index="/"><h1>SYP</h1></el-menu-item>
+      <el-menu-item index="/all">All</el-menu-item>
+      <el-menu-item index="/1">Weekly best</el-menu-item>
+      <el-menu-item index="/2">Hashtags</el-menu-item>
+      <el-menu-item index="/3">Random</el-menu-item>
+      <div class="flex-grow" />
+      <el-menu-item index="/write">Share</el-menu-item>
+      <el-menu-item v-if="!isLoggedIn" index="/login">Login</el-menu-item>
+      <el-sub-menu v-if="isLoggedIn">
+        <template #title>My Page</template>
+        <el-menu-item index="/My Playlist">My Playlist</el-menu-item>
+        <el-menu-item index="/likes">Likes</el-menu-item>
+        <el-menu-item index="/setting">Setting</el-menu-item>
+        <el-menu-item v-if="isLoggedIn" @click="logout()">Logout</el-menu-item>
+      </el-sub-menu>
     </el-menu>
+    <!--    <el-menu-->
+    <!--      mode="horizontal"-->
+    <!--      class="menu-right"-->
+    <!--      :ellipsis="false"-->
+    <!--      :default-active="rightMenuActive"-->
+    <!--      router-->
+    <!--    >-->
+
+    <!--    </el-menu>-->
   </el-header>
 </template>
 
 <script setup lang="ts">
+import { useRoute, useRouter } from 'vue-router'
+import { computed } from 'vue'
+import { useAuthStore } from '@/stores/auth'
+import axios from 'axios'
+import { ElMessage, ElMessageBox } from 'element-plus'
 
+const route = useRoute()
+const router = useRouter()
+const authStore = useAuthStore()
+const isLoggedIn = computed(() => authStore.isLoggedIn)
+
+function logout() {
+  ElMessageBox.confirm('로그아웃을 하시겠습니까??', 'Warning', {
+    title: '로그아웃',
+    confirmButtonText: '로그아웃',
+    cancelButtonText: '취소',
+    type: 'warning'
+  }).then(() => {
+    axios.post('/logout').then(() => {
+      authStore.logout()
+      ElMessage({ type: 'success', message: '로그아웃되었습니다.' })
+    })
+  })
+}
 </script>
 
 <style scoped>
 .header {
-  padding : 0;
-  height: 60px;
+  padding: 0;
+}
+.flex-grow {
+  flex-grow: 1;
 }
 </style>

--- a/front/src/entity/member/Login.ts
+++ b/front/src/entity/member/Login.ts
@@ -1,0 +1,4 @@
+export default class Login {
+  public username = ''
+  public password = ''
+}

--- a/front/src/main.ts
+++ b/front/src/main.ts
@@ -2,6 +2,7 @@ import './assets/main.css'
 
 import { createApp } from 'vue'
 import { createPinia } from 'pinia'
+import piniaPluginPersistedstate, { createPersistedState } from 'pinia-plugin-persistedstate'
 
 import App from './App.vue'
 import router from './router'
@@ -17,9 +18,24 @@ import axios from 'axios'
 const app = createApp(App)
 
 app.use(ElementPlus)
-app.use(createPinia())
 app.use(router)
+app.use(
+  createPinia().use(
+    createPersistedState({
+      storage: localStorage,
+      auto: true
+    })
+  )
+)
 axios.defaults.baseURL = 'http://localhost:8080'
 axios.defaults.withCredentials = true
 
 app.mount('#app')
+
+// const pinia = createPinia()
+// pinia.use(
+//   createPersistedState({
+//     storage: localStorage,
+//     auto: true
+//   })
+// )

--- a/front/src/router/index.ts
+++ b/front/src/router/index.ts
@@ -1,8 +1,10 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import HomeView from '../views/HomeView.vue'
 import WriteView from '@/views/WriteView.vue'
-import ReadView from '@/views/ReadView.vue'
 import EditView from '@/views/EditView.vue'
+import LoginView from '@/views/LoginView.vue'
+import ReadView2 from '@/views/ReadView.vue'
+import ReadView from '@/views/ReadView.vue'
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -11,6 +13,11 @@ const router = createRouter({
       path: '/',
       name: 'home',
       component: HomeView
+    },
+    {
+      path: '/login',
+      name: 'login',
+      component: LoginView
     },
     {
       path: '/write',

--- a/front/src/stores/auth.ts
+++ b/front/src/stores/auth.ts
@@ -1,0 +1,18 @@
+import { defineStore } from 'pinia'
+
+export const useAuthStore = defineStore('auth', {
+  state: () => ({
+    nickname: '',
+    isLoggedIn: false
+  }),
+  actions: {
+    login(nickname: string) {
+      this.nickname = nickname
+      this.isLoggedIn = true
+    },
+    logout() {
+      this.nickname = ''
+      this.isLoggedIn = false
+    }
+  }
+})

--- a/front/src/views/LoginView.vue
+++ b/front/src/views/LoginView.vue
@@ -1,0 +1,50 @@
+<script setup lang="ts">
+import { reactive, ref } from 'vue'
+import Login from '@/entity/member/Login'
+import axios from 'axios'
+import { ElMessage } from 'element-plus'
+import HttpError from '@/http/HttpError'
+import { useRouter } from 'vue-router'
+import { useAuthStore } from '@/stores/auth'
+
+const state = ref(new Login())
+const authStore = useAuthStore()
+const router = useRouter()
+
+const doLogin = () => {
+  axios
+    .post('/api/login', state.value)
+    .then(() => {
+      console.log(authStore.isLoggedIn)
+      ElMessage({ type: 'success', message: '환영합니다 :)' })
+
+      axios.get('/api/members/me').then((response) => authStore.login(response.data.nickname))
+      console.log(authStore)
+      router.replace({ name: 'home' })
+    })
+    .catch(() => {
+      ElMessage({ type: 'error', message: '로그인 실패' })
+    })
+}
+</script>
+<template>
+  <el-row>
+    <el-col :span="5" :offset="9">
+      <el-form label-position="top">
+        <el-form-item label="아이디">
+          <el-input v-model="state.username"></el-input>
+        </el-form-item>
+
+        <el-form-item label="비밀번호">
+          <el-input type="password" v-model="state.password"></el-input>
+        </el-form-item>
+
+        <el-form-item>
+          <el-button type="primary" style="width: 100%" @click="doLogin()">로그인</el-button>
+        </el-form-item>
+      </el-form>
+    </el-col>
+  </el-row>
+</template>
+
+<style scoped></style>

--- a/src/main/java/com/isack/syp/member/controller/MemberController.java
+++ b/src/main/java/com/isack/syp/member/controller/MemberController.java
@@ -1,11 +1,14 @@
 package com.isack.syp.member.controller;
 
+import com.isack.syp.member.dto.MemberDto;
 import com.isack.syp.member.dto.request.LoginRequest;
 import com.isack.syp.member.dto.request.MemberJoinRequest;
 import com.isack.syp.member.dto.response.MemberResponse;
 import com.isack.syp.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
@@ -20,6 +23,15 @@ public class MemberController {
     @GetMapping("/{nickname}")
     public ResponseEntity<MemberResponse> findMember(@PathVariable String nickname) {
         MemberResponse memberResponse = MemberResponse.from(memberService.findByNickname(nickname));
+        return ResponseEntity.ok(memberResponse);
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<MemberResponse> getMe(@AuthenticationPrincipal MemberDto memberDto) {
+        if (memberDto == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        MemberResponse memberResponse = MemberResponse.from(memberService.findByNickname(memberDto.getNickname()));
         return ResponseEntity.ok(memberResponse);
     }
 


### PR DESCRIPTION
# 작업내용
* 로그인 시 브라우저의 로컬 스토리지에 상태를 저장하도록 했습니다.

# 작업상세
* 상태저장을 위해 `pinia` 와 `pinia-plugin0persistedstate`의 의존성을 추가했습니다.
* 이제 로그인 시 서버에서 닉네임을 가져오고 브라우저의 로컬스토리지에 닉네임과 로그인 상태를 저장합니다.

# 관련 이슈
* This closes #64 
