### PR TITLE
feat: 좋아요 API 구현

### DIFF
--- a/src/main/java/com/isack/syp/article/domain/Article.java
+++ b/src/main/java/com/isack/syp/article/domain/Article.java
@@ -27,7 +27,9 @@ public class Article extends AuditingFields {
     @Column(length = 1000)
     private String content;
 
-    private Integer commentCount = 0;
+    private Integer commentCount;
+
+    private Integer likesCount;
 
     private String thumbnailUrl;
 
@@ -45,6 +47,8 @@ public class Article extends AuditingFields {
         this.title = title;
         this.content = content;
         this.thumbnailUrl = thumbnailUrl;
+        this.commentCount = 0;
+        this.likesCount = 0;
     }
 
     public static Article of(Member member, String title, String content, String thumbnailUrl){
@@ -63,6 +67,14 @@ public class Article extends AuditingFields {
 
     public void addCommentCount() {
         this.commentCount++;
+    }
+
+    public void increaseLikes() {
+        this.likesCount++;
+    }
+
+    public void decreaseLikes() {
+        this.likesCount--;
     }
 
     public boolean isAuthor(Long memberId) {

--- a/src/main/java/com/isack/syp/article/dto/ArticleDto.java
+++ b/src/main/java/com/isack/syp/article/dto/ArticleDto.java
@@ -20,10 +20,11 @@ public class ArticleDto {
     private LocalDateTime createdAt;
     private String createdBy;
     private Integer commentCount;
+    private Integer likesCount;
     private String thumbnailUrl;
     private List<itemDto> itemDtoList;
 
-    public ArticleDto(Long id, MemberDto memberDto, String title, String content, LocalDateTime createdAt, String createdBy, Integer commentsCount, String thumbnailUrl,List<itemDto> itemDtoList) {
+    public ArticleDto(Long id, MemberDto memberDto, String title, String content, LocalDateTime createdAt, String createdBy, Integer commentsCount, Integer likesCount,String thumbnailUrl,List<itemDto> itemDtoList) {
         this.id = id;
         this.memberDto = memberDto;
         this.title = title;
@@ -31,12 +32,13 @@ public class ArticleDto {
         this.createdAt = createdAt;
         this.createdBy = createdBy;
         this.commentCount = commentsCount;
+        this.likesCount = likesCount;
         this.thumbnailUrl = thumbnailUrl;
         this.itemDtoList = itemDtoList;
     }
 
     public static ArticleDto of(MemberDto memberDto, String title, String content, String thumbnailUrl,List<itemDto> itemDtoList) {
-        return new ArticleDto(null, memberDto, title, content, null, null, null, thumbnailUrl, itemDtoList);
+        return new ArticleDto(null, memberDto, title, content, null, null, null, null, thumbnailUrl, itemDtoList);
     }
 
 
@@ -57,6 +59,7 @@ public class ArticleDto {
                 article.getCreatedAt(),
                 article.getCreatedBy(),
                 article.getCommentCount(),
+                article.getLikesCount(),
                 article.getThumbnailUrl(),
                 itemDtoList
         );
@@ -71,6 +74,7 @@ public class ArticleDto {
                 article.getCreatedAt(),
                 article.getCreatedBy(),
                 article.getCommentCount(),
+                article.getLikesCount(),
                 article.getThumbnailUrl(),
                 null
         );

--- a/src/main/java/com/isack/syp/article/dto/response/ArticleResponse.java
+++ b/src/main/java/com/isack/syp/article/dto/response/ArticleResponse.java
@@ -19,6 +19,7 @@ public class ArticleResponse {
     private String createdBy;
     private String createdAt;
     private Integer commentCount;
+    private Integer likesCount;
 
     public static ArticleResponse from(ArticleDto articleDto) {
         return new ArticleResponse(
@@ -28,7 +29,8 @@ public class ArticleResponse {
                 articleDto.getItemDtoList(),
                 articleDto.getCreatedBy(),
                 articleDto.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy년 MM월 dd일 HH시 mm분")),
-                articleDto.getCommentCount()
+                articleDto.getCommentCount(),
+                articleDto.getLikesCount()
         );
     }
 }

--- a/src/main/java/com/isack/syp/article/dto/response/SimpleArticleResponse.java
+++ b/src/main/java/com/isack/syp/article/dto/response/SimpleArticleResponse.java
@@ -17,6 +17,7 @@ public class SimpleArticleResponse {
     private String createdBy;
     private String createdAt;
     private Integer commentCount;
+    private Integer likesCount;
 
     public static SimpleArticleResponse from(ArticleDto articleDto) {
         return new SimpleArticleResponse(
@@ -25,7 +26,8 @@ public class SimpleArticleResponse {
                 articleDto.getThumbnailUrl(),
                 articleDto.getCreatedBy(),
                 articleDto.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy년 MM월 dd일 HH시 mm분")),
-                articleDto.getCommentCount()
+                articleDto.getCommentCount(),
+                articleDto.getLikesCount()
         );
     }
 }

--- a/src/main/java/com/isack/syp/config/handler/LoginSuccessHandler.java
+++ b/src/main/java/com/isack/syp/config/handler/LoginSuccessHandler.java
@@ -1,7 +1,6 @@
 package com.isack.syp.config.handler;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.isack.syp.config.MemberPrincipal;
 import com.isack.syp.member.dto.MemberDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -12,7 +11,6 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.security.Principal;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static javax.servlet.http.HttpServletResponse.SC_OK;

--- a/src/main/java/com/isack/syp/likes/Likes.java
+++ b/src/main/java/com/isack/syp/likes/Likes.java
@@ -1,0 +1,31 @@
+package com.isack.syp.likes;
+
+import lombok.Getter;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+@Getter
+@Entity
+public class Likes {
+
+    @GeneratedValue
+    @Id
+    private Long id;
+
+    private Long memberId;
+
+    private Long articleId;
+
+    protected Likes() {}
+
+    private Likes(Long memberId, Long articleId) {
+        this.memberId = memberId;
+        this.articleId = articleId;
+    }
+
+    public static Likes of(Long memberId, Long articleId) {
+        return new Likes(memberId, articleId);
+    }
+}

--- a/src/main/java/com/isack/syp/likes/LikesController.java
+++ b/src/main/java/com/isack/syp/likes/LikesController.java
@@ -1,0 +1,24 @@
+package com.isack.syp.likes;
+
+import com.isack.syp.member.dto.MemberDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/likes")
+@RestController
+public class LikesController {
+
+    private final LikesService likesService;
+
+    @PostMapping("/{articleId}")
+    public ResponseEntity<Void> likeArticle(@PathVariable Long articleId, @AuthenticationPrincipal MemberDto memberDto) {
+        likesService.likeArticle(articleId, memberDto);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/isack/syp/likes/LikesRepository.java
+++ b/src/main/java/com/isack/syp/likes/LikesRepository.java
@@ -1,0 +1,12 @@
+package com.isack.syp.likes;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface LikesRepository extends JpaRepository<Likes, Long> {
+
+    Optional<Likes> findByMemberIdAndArticleId(Long memberId, Long articleId);
+
+}

--- a/src/main/java/com/isack/syp/likes/LikesService.java
+++ b/src/main/java/com/isack/syp/likes/LikesService.java
@@ -1,0 +1,31 @@
+package com.isack.syp.likes;
+
+import com.isack.syp.article.domain.Article;
+import com.isack.syp.article.repository.ArticleRepository;
+import com.isack.syp.member.dto.MemberDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class LikesService {
+
+    private final LikesRepository likesRepository;
+    private final ArticleRepository articleRepository;
+
+    @Transactional
+    public void likeArticle(Long articleId, MemberDto memberDto) {
+        Long memberId = memberDto.getId();
+        Article article = articleRepository.findById(articleId).orElseThrow(RuntimeException::new);
+        likesRepository.findByMemberIdAndArticleId(memberId, articleId)
+                        .ifPresentOrElse(existingLike -> { // 이미 좋아요를 누른 경우, 좋아요를 취소하고 개수 감소 처리
+                            likesRepository.delete(existingLike);
+                            article.decreaseLikes();
+                        }, () -> { // 좋아요를 누르지 않은 경우, 좋아요를 저장하고 증가 처리
+                            likesRepository.save(Likes.of(memberId, articleId));
+                            article.increaseLikes();
+                        });
+    }
+}


### PR DESCRIPTION
# 작업 내용
"좋아요" 기능을 담당하는 API 를 구현했습니다.

# 작업 상세
* feat: 각 dto 필드에 `likesCount` 추가
* feat: `Article` 엔티티안에 `likesCount` 증감 구현
  * "좋아요의 수" 를 위해 매 요청마다 `count` 쿼리를 날리기에는 소모값이 크다 생각해서 반정규화를 했습니다.
    * `article` db테이블이 필드에 `likes_count` 를 가집니다.
* 좋아요 API 구현
  * 호출 시 `Article` 의 `LikesCount` 를 1 증가시키고, `likes` db테이블에 저장합니다.
  * 이미 존재하는 `Article` 과 `Member` 의 쌍일 시, "좋아요 취소" 로 판단해서 `LikesCount` 를 1 감소시키고, `likes` db테이블에서 그 row 를 삭제합니다.

# 관련 이슈
* This closes #71 