### PR TITLE
feat: 플레이리스트 관련 CRUD API 구현

### DIFF
--- a/src/main/java/com/isack/syp/item/ItemService.java
+++ b/src/main/java/com/isack/syp/item/ItemService.java
@@ -11,6 +11,10 @@ public class ItemService {
 
     private final ItemRepository itemRepository;
 
+    public Item findById(Long itemId) {
+        return itemRepository.findById(itemId).orElseThrow(RuntimeException::new);
+    }
+
     @Transactional
     public Long saveItem(Item item) {
         return itemRepository.findByVideoId(item.getVideoId())

--- a/src/main/java/com/isack/syp/playlist/Playlist.java
+++ b/src/main/java/com/isack/syp/playlist/Playlist.java
@@ -1,0 +1,45 @@
+package com.isack.syp.playlist;
+
+import com.isack.syp.audit.AuditingFields;
+import lombok.Getter;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+@Getter
+@Entity
+public class Playlist extends AuditingFields {
+
+    @GeneratedValue
+    @Id
+    private Long id;
+
+    private String title;
+
+    private String thumbnailUrl;
+
+    private Long memberId;
+
+    private Boolean deleted = Boolean.FALSE;
+
+    protected Playlist() {}
+
+    private Playlist(String title, String thumbnailUrl, Long memberId) {
+        this.title = title;
+        this.thumbnailUrl = thumbnailUrl;
+        this.memberId = memberId;
+    }
+
+    public static Playlist of(String title, String thumbnailUrl, Long memberId) {
+        return new Playlist(title, thumbnailUrl, memberId);
+    }
+
+    public boolean isAuthor(Long memberId) {
+        if (memberId == null) {
+            return false;
+        }
+        return this.memberId.equals(memberId);
+    }
+}
+

--- a/src/main/java/com/isack/syp/playlist/PlaylistController.java
+++ b/src/main/java/com/isack/syp/playlist/PlaylistController.java
@@ -1,0 +1,59 @@
+package com.isack.syp.playlist;
+
+import com.isack.syp.item.ItemDto;
+import com.isack.syp.member.dto.MemberDto;
+import com.isack.syp.playlist.dto.request.PlaylistRequest;
+import com.isack.syp.playlist.dto.response.PlaylistResponse;
+import com.isack.syp.playlist.dto.response.PlaylistsResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/playlists")
+@RestController
+public class PlaylistController {
+
+    private final PlaylistService playlistService;
+
+    @GetMapping("/{playlistId}")
+    public ResponseEntity<PlaylistResponse> findPlaylist(@PathVariable Long playlistId) {
+        PlaylistResponse playlistResponse = playlistService.findById(playlistId);
+        return ResponseEntity.ok(playlistResponse);
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<PlaylistsResponse> findMyPlaylists(@AuthenticationPrincipal MemberDto memberDto) {
+        PlaylistsResponse playlistsResponse = playlistService.findByMemberId(memberDto.getId());
+        return ResponseEntity.ok(playlistsResponse);
+    }
+
+    @PostMapping
+    public ResponseEntity<Void> savePlaylist(@RequestBody PlaylistRequest playlistRequest, @AuthenticationPrincipal MemberDto memberDto) {
+        Long playlistId = playlistService.savePlaylist(playlistRequest, memberDto.getId());
+        return ResponseEntity.created(URI.create("/api/playlists/" + playlistId)).build();
+    }
+
+    @PostMapping("/{playlistId}")
+    public ResponseEntity<PlaylistResponse> addItem(@RequestBody ItemDto itemDto, @PathVariable Long playlistId, @AuthenticationPrincipal MemberDto memberDto) {
+        PlaylistResponse playlistResponse = playlistService.addItem(itemDto, playlistId, memberDto);
+        return ResponseEntity.ok(playlistResponse);
+    }
+
+    @DeleteMapping("/{playlistId}/{itemId}")
+    public ResponseEntity<Void> deleteItem(@PathVariable Long playlistId, @PathVariable Long itemId, @AuthenticationPrincipal MemberDto memberDto) {
+        playlistService.deleteItem(playlistId, itemId, memberDto);
+
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/{playlistId}")
+    public ResponseEntity<Void> deletePlaylist(@PathVariable Long playlistId, @AuthenticationPrincipal MemberDto memberDto) {
+        playlistService.deletePlaylist(playlistId, memberDto);
+        return ResponseEntity.noContent().build();
+    }
+
+}

--- a/src/main/java/com/isack/syp/playlist/PlaylistRepository.java
+++ b/src/main/java/com/isack/syp/playlist/PlaylistRepository.java
@@ -1,0 +1,9 @@
+package com.isack.syp.playlist;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface PlaylistRepository extends JpaRepository<Playlist, Long>{
+    List<Playlist> findByMemberId(Long memberId);
+}

--- a/src/main/java/com/isack/syp/playlist/PlaylistService.java
+++ b/src/main/java/com/isack/syp/playlist/PlaylistService.java
@@ -1,0 +1,108 @@
+package com.isack.syp.playlist;
+
+import com.isack.syp.item.Item;
+import com.isack.syp.item.ItemDto;
+import com.isack.syp.item.ItemService;
+import com.isack.syp.member.dto.MemberDto;
+import com.isack.syp.playlist.dto.request.PlaylistRequest;
+import com.isack.syp.playlist.dto.response.PlaylistResponse;
+import com.isack.syp.playlist.dto.response.PlaylistsResponse;
+import com.isack.syp.playlistitem.PlaylistItem;
+import com.isack.syp.playlistitem.PlaylistItemRepository;
+import com.isack.syp.playlistitem.PlaylistItemService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class PlaylistService {
+
+    private final PlaylistRepository playlistRepository;
+    private final PlaylistItemService playlistItemService;
+    private final PlaylistItemRepository playlistItemRepository;
+    private final ItemService itemService;
+
+    public PlaylistResponse findById(Long playlistId) {
+        Playlist playlist = playlistRepository.findById(playlistId).orElseThrow(RuntimeException::new);
+        List<Item> items = playlistItemService.findItemsByPlaylistId(playlistId);
+        List<ItemDto> itemDtoList = items.stream().map(ItemDto::from).toList();
+        return PlaylistResponse.from(playlist, itemDtoList);
+    }
+
+    public PlaylistsResponse findByMemberId(Long memberId) {
+        List<Playlist> playlists = playlistRepository.findByMemberId(memberId);
+        List<PlaylistResponse> playlistResponses = new ArrayList<>();
+        for (Playlist playlist : playlists) {
+            List<Item> items = playlistItemService.findItemsByPlaylistId(playlist.getId());
+            List<ItemDto> itemDtoList = items.stream().map(ItemDto::from).toList();
+            PlaylistResponse playlistResponse = PlaylistResponse.from(playlist, itemDtoList);
+            playlistResponses.add(playlistResponse);
+        }
+        return PlaylistsResponse.from(playlistResponses);
+    }
+
+    @Transactional
+    public Long savePlaylist(PlaylistRequest playlistRequest, Long memberId) {
+        List<Item> items = playlistRequest.getItemDtoList().stream().map(ItemDto::toEntity).toList();
+        for (Item item : items) {
+            itemService.saveItem(item);
+        }
+
+        Playlist playlist = playlistRequest.toEntity(memberId);
+        playlistRepository.save(playlist);
+
+        List<PlaylistItem> playlistItems = items.stream().map(item -> PlaylistItem.of(playlist.getId(), item.getId())).toList();
+        playlistItemService.saveAllPlaylistItem(playlistItems);
+
+        return playlist.getId();
+    }
+
+    @Transactional
+    public void deletePlaylist(Long playlistId, MemberDto memberDto) {
+        Playlist playlist = playlistRepository.findById(playlistId).orElseThrow(RuntimeException::new);
+        validateAuthor(memberDto, playlist);
+        playlistRepository.delete(playlist);
+        playlistItemService.deletePlaylistItem(playlistId);
+    }
+
+    @Transactional
+    public PlaylistResponse addItem(ItemDto itemDto, Long playlistId, MemberDto memberDto) {
+        Playlist playlist = playlistRepository.findById(playlistId).orElseThrow(RuntimeException::new);
+        validateAuthor(memberDto, playlist);
+
+        // 새로운 아이템을 ITEM, PLAYLIST_ITEM 테이블에 각각 저장
+        Long itemId = itemService.saveItem(itemDto.toEntity());
+        if (!playlistItemRepository.existsByPlaylistIdAndItemId(playlistId, itemId)) {
+            PlaylistItem newPlaylistItem = PlaylistItem.of(playlistId, itemId);
+            playlistItemRepository.save(newPlaylistItem);
+        }
+
+        // playlistId 로 PlaylistItem 조회 후 List<Item> -> List<ItemDto> 로 변환 후 반환
+        List<PlaylistItem> playlistItems = playlistItemRepository.findByPlaylistId(playlistId);
+        List<Item> items = playlistItems.stream().map(playlistItem -> itemService.findById(playlistItem.getItemId())).toList();
+        List<ItemDto> itemDtoList = items.stream().map(ItemDto::from).toList();
+
+
+        return PlaylistResponse.from(playlist, itemDtoList);
+    }
+
+    @Transactional
+    public void deleteItem(Long playlistId, Long itemId, MemberDto memberDto) {
+        Playlist playlist = playlistRepository.findById(playlistId).orElseThrow(RuntimeException::new);
+        validateAuthor(memberDto, playlist);
+        playlistItemService.deleteItemInPlaylist(playlistId, itemId);
+    }
+
+    public void validateAuthor(MemberDto memberDto, Playlist playlist) {
+        if (!playlist.isAuthor(memberDto.getId())) {
+            throw new RuntimeException("작성자가 아닙니다.");
+        }
+    }
+}

--- a/src/main/java/com/isack/syp/playlist/dto/request/PlaylistRequest.java
+++ b/src/main/java/com/isack/syp/playlist/dto/request/PlaylistRequest.java
@@ -1,0 +1,24 @@
+package com.isack.syp.playlist.dto.request;
+
+import com.isack.syp.item.ItemDto;
+import com.isack.syp.playlist.Playlist;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+public class PlaylistRequest {
+
+    private String title;
+
+    private String thumbnailUrl;
+
+    private List<ItemDto> itemDtoList;
+
+    public Playlist toEntity(Long memberId) {
+        return Playlist.of(title, thumbnailUrl, memberId);
+    }
+
+}

--- a/src/main/java/com/isack/syp/playlist/dto/response/PlaylistResponse.java
+++ b/src/main/java/com/isack/syp/playlist/dto/response/PlaylistResponse.java
@@ -1,0 +1,29 @@
+package com.isack.syp.playlist.dto.response;
+
+import com.isack.syp.item.ItemDto;
+import com.isack.syp.playlist.Playlist;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class PlaylistResponse {
+    private Long id;
+    private String title;
+    private String createdBy;
+    private String createdAt;
+    private List<ItemDto> items;
+
+    public static PlaylistResponse from(Playlist playlist, List<ItemDto> items) {
+        return new PlaylistResponse(
+                playlist.getId(),
+                playlist.getTitle(),
+                playlist.getCreatedBy(),
+                playlist.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy년 MM월 dd일 HH시 mm분")),
+                items);
+    }
+}

--- a/src/main/java/com/isack/syp/playlist/dto/response/PlaylistsResponse.java
+++ b/src/main/java/com/isack/syp/playlist/dto/response/PlaylistsResponse.java
@@ -1,0 +1,17 @@
+package com.isack.syp.playlist.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class PlaylistsResponse {
+    private List<PlaylistResponse> playlistResponses;
+
+    public static PlaylistsResponse from(List<PlaylistResponse> playlistResponses) {
+        return new PlaylistsResponse(playlistResponses);
+    }
+}

--- a/src/main/java/com/isack/syp/playlistitem/PlaylistItem.java
+++ b/src/main/java/com/isack/syp/playlistitem/PlaylistItem.java
@@ -1,0 +1,37 @@
+package com.isack.syp.playlistitem;
+
+import lombok.Getter;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+@Getter
+@SQLDelete(sql = "UPDATE playlist_item SET deleted = true WHERE id = ?")
+@Where(clause = "deleted = false")
+@Entity
+public class PlaylistItem {
+
+    @GeneratedValue
+    @Id
+    private Long id;
+
+    private Long playlistId;
+
+    private Long itemId;
+
+    private Boolean deleted = Boolean.FALSE;
+
+    protected PlaylistItem() {}
+
+    private PlaylistItem(Long playlistId, Long itemId) {
+        this.playlistId = playlistId;
+        this.itemId = itemId;
+    }
+
+    public static PlaylistItem of(Long playlistId, Long itemId) {
+        return new PlaylistItem(playlistId, itemId);
+    }
+}

--- a/src/main/java/com/isack/syp/playlistitem/PlaylistItemRepository.java
+++ b/src/main/java/com/isack/syp/playlistitem/PlaylistItemRepository.java
@@ -1,0 +1,14 @@
+package com.isack.syp.playlistitem;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface PlaylistItemRepository extends JpaRepository<PlaylistItem, Long> {
+
+    List<PlaylistItem> findByPlaylistId(Long playlistId);
+
+    boolean existsByPlaylistIdAndItemId(Long playlistId, Long itemId);
+
+    void deleteByPlaylistIdAndItemId(Long playlistId, Long itemId);
+}

--- a/src/main/java/com/isack/syp/playlistitem/PlaylistItemService.java
+++ b/src/main/java/com/isack/syp/playlistitem/PlaylistItemService.java
@@ -1,0 +1,39 @@
+package com.isack.syp.playlistitem;
+
+import com.isack.syp.item.Item;
+import com.isack.syp.item.ItemService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class PlaylistItemService {
+
+    private final PlaylistItemRepository playlistItemRepository;
+    private final ItemService itemService;
+
+    public List<Item> findItemsByPlaylistId(Long playlistId) {
+        List<PlaylistItem> playlistItems = playlistItemRepository.findByPlaylistId(playlistId);
+        return playlistItems.stream().map(playlistItem -> itemService.findById(playlistItem.getItemId())).toList();
+    }
+
+    @Transactional
+    public void saveAllPlaylistItem(List<PlaylistItem> playlistItems) {
+        playlistItemRepository.saveAll(playlistItems);
+    }
+
+    @Transactional
+    public void deletePlaylistItem(Long playlistId) {
+        List<PlaylistItem> playlistItems = playlistItemRepository.findByPlaylistId(playlistId);
+        playlistItemRepository.deleteAll(playlistItems);
+    }
+
+    @Transactional
+    public void deleteItemInPlaylist(Long playlistId, Long itemId) {
+        playlistItemRepository.deleteByPlaylistIdAndItemId(playlistId, itemId);
+    }
+}


### PR DESCRIPTION
# 작업 내용
* 플레이리스트 관련 CRUD API 와 플레이리스트, 아이템의 연관관계 관련 비지니스 로직을 구현했습니다.

# 작업 상세
* playlist_item 테이블 관련 비지니스로직 구현
  * 플레이리스트와 아이템은 N:M 이기에 중간에 연관관계 테이블을 하나 따로 두고 관련 로직을 구현
* 플레이리스트 CRUD API 구현
  * 하나 조회 API
  * 저장, 삭제 API
  * 아이템 하나 추가, 삭제 API
  * 나의 플레이리스트 모두 조회

# 관련 이슈
*This closes #73 
