### PR TITLE
feat: 좋아요 api 분리와 프론트 구현

### DIFF
--- a/front/src/views/ReadView.vue
+++ b/front/src/views/ReadView.vue
@@ -4,19 +4,23 @@ import axios from 'axios'
 import Article from '@/entity/article/Article'
 import { ElMessage, ElMessageBox } from 'element-plus'
 import { useRouter } from 'vue-router'
-import { Comment, Star, UserFilled } from '@element-plus/icons-vue'
+import { Comment, Star, StarFilled, UserFilled } from '@element-plus/icons-vue'
 
 const props = defineProps<{ articleId: string }>()
 
 const router = useRouter()
 
 const article = ref(new Article())
+const likesCount = ref(0)
+const isLiked = ref(false)
 
 const getArticle = () => {
   axios
     .get(`/api/articles/${props.articleId}`)
     .then((response) => {
       article.value = new Article(response.data)
+      likesCount.value = response.data.likesCount
+      isLiked.value = response.data.isLiked
       // console.log(article.value)
       // console.log(article.value.playlistItem)
     })
@@ -41,6 +45,32 @@ const deleteArticle = () => {
 
 const moveToEdit = () => {
   router.push({ name: 'update', params: { articleId: props.articleId } })
+}
+
+const toggleLikeArticle = () => {
+  if (isLiked.value) {
+    axios
+      .delete(`/api/${props.articleId}/likes`)
+      .then((response) => {
+        likesCount.value = response.data.likesCount
+        isLiked.value = false
+        ElMessage({ type: 'success', message: '좋아요가 취소되었습니다.' })
+      })
+      .catch((e) => {
+        console.error('좋아요 취소 에러', e)
+      })
+  } else {
+    axios
+      .post(`/api/${props.articleId}/likes`)
+      .then((response) => {
+        likesCount.value = response.data.likesCount
+        isLiked.value = true
+        ElMessage({ type: 'success', message: '좋아요!' })
+      })
+      .catch((e) => {
+        console.error('좋아요 에러', e)
+      })
+  }
 }
 
 const initials = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j']
@@ -96,8 +126,10 @@ onMounted(() => {
           <el-button color="#626aef" @click="moveToEdit()"
             >1<el-icon><Comment /></el-icon
           ></el-button>
-          <el-button color="#626aef" @click="moveToEdit()"
-            >1<el-icon><Star /></el-icon
+          <el-button color="#626aef" @click="toggleLikeArticle()"
+            >{{ likesCount
+            }}<el-icon>
+              <component :is="isLiked ? StarFilled : Star" /> </el-icon
           ></el-button>
           <!--          <el-button color="#626aef" @click="moveToEdit()"><el-icon><StarFilled /></el-icon></el-button>-->
         </div>

--- a/src/main/java/com/isack/syp/InitDb.java
+++ b/src/main/java/com/isack/syp/InitDb.java
@@ -1,6 +1,7 @@
 package com.isack.syp;
 
 import com.isack.syp.article.domain.Article;
+import com.isack.syp.articleItem.ArticleItem;
 import com.isack.syp.item.Item;
 import com.isack.syp.comment.domain.Comment;
 import com.isack.syp.member.domain.Member;
@@ -58,6 +59,14 @@ public class InitDb {
                 items.add(item2);
                 items.add(item3);
                 items.forEach(em::persist);
+                List<ArticleItem> articleItems = new ArrayList<>();
+                ArticleItem articleItem1 = ArticleItem.of(article.getId(), item1.getId());
+                ArticleItem articleItem2 = ArticleItem.of(article.getId(), item2.getId());
+                ArticleItem articleItem3 = ArticleItem.of(article.getId(), item3.getId());
+                articleItems.add(articleItem1);
+                articleItems.add(articleItem2);
+                articleItems.add(articleItem3);
+                articleItems.forEach(em::persist);
                 //댓글 생성
                 for (int k = 1; k <= 5; k++) {
                     Comment comment = Comment.of(article, member, "Comment is...");

--- a/src/main/java/com/isack/syp/article/controller/ArticleController.java
+++ b/src/main/java/com/isack/syp/article/controller/ArticleController.java
@@ -6,6 +6,7 @@ import com.isack.syp.article.dto.response.ArticleResponse;
 import com.isack.syp.article.dto.response.ArticlesResponse;
 import com.isack.syp.article.dto.response.SimpleArticleResponse;
 import com.isack.syp.article.service.ArticleService;
+import com.isack.syp.likes.LikesService;
 import com.isack.syp.member.dto.MemberDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -24,6 +25,7 @@ import java.net.URI;
 public class ArticleController {
 
     private final ArticleService articleService;
+    private final LikesService likesService;
 
     @GetMapping
     public ResponseEntity<ArticlesResponse> findArticles(
@@ -35,8 +37,12 @@ public class ArticleController {
     }
 
     @GetMapping("/{articleId}")
-    public ResponseEntity<ArticleResponse> findArticle(@PathVariable Long articleId) {
-        ArticleResponse articleResponse = ArticleResponse.from(articleService.findById(articleId));
+    public ResponseEntity<ArticleResponse> findArticle(@PathVariable Long articleId, @AuthenticationPrincipal MemberDto memberDto) {
+        boolean isLiked = false;
+        if (memberDto != null) {
+            isLiked = likesService.isLiked(articleId, memberDto);
+        }
+        ArticleResponse articleResponse = ArticleResponse.from(articleService.findById(articleId), isLiked);
         return ResponseEntity.ok(articleResponse);
     }
 

--- a/src/main/java/com/isack/syp/article/dto/response/ArticleResponse.java
+++ b/src/main/java/com/isack/syp/article/dto/response/ArticleResponse.java
@@ -20,8 +20,9 @@ public class ArticleResponse {
     private String createdAt;
     private Integer commentCount;
     private Integer likesCount;
+    private Boolean isLiked;
 
-    public static ArticleResponse from(ArticleDto articleDto) {
+    public static ArticleResponse from(ArticleDto articleDto, boolean isLiked) {
         return new ArticleResponse(
                 articleDto.getId(),
                 articleDto.getTitle(),
@@ -30,7 +31,8 @@ public class ArticleResponse {
                 articleDto.getCreatedBy(),
                 articleDto.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy년 MM월 dd일 HH시 mm분")),
                 articleDto.getCommentCount(),
-                articleDto.getLikesCount()
+                articleDto.getLikesCount(),
+                isLiked
         );
     }
 }

--- a/src/main/java/com/isack/syp/likes/Likes.java
+++ b/src/main/java/com/isack/syp/likes/Likes.java
@@ -1,11 +1,14 @@
 package com.isack.syp.likes;
 
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Entity
 public class Likes {
@@ -17,8 +20,6 @@ public class Likes {
     private Long memberId;
 
     private Long articleId;
-
-    protected Likes() {}
 
     private Likes(Long memberId, Long articleId) {
         this.memberId = memberId;

--- a/src/main/java/com/isack/syp/likes/LikesController.java
+++ b/src/main/java/com/isack/syp/likes/LikesController.java
@@ -4,21 +4,24 @@ import com.isack.syp.member.dto.MemberDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
-@RequestMapping("/api/likes")
+@RequestMapping("/api/{articleId}")
 @RestController
 public class LikesController {
 
     private final LikesService likesService;
 
-    @PostMapping("/{articleId}")
-    public ResponseEntity<Void> likeArticle(@PathVariable Long articleId, @AuthenticationPrincipal MemberDto memberDto) {
-        likesService.likeArticle(articleId, memberDto);
-        return ResponseEntity.noContent().build();
+    @PostMapping("/likes")
+    public ResponseEntity<LikesResponse> likeArticle(@PathVariable Long articleId, @AuthenticationPrincipal MemberDto memberDto) {
+        Integer likesCount = likesService.likeArticle(articleId, memberDto);
+        return ResponseEntity.ok(LikesResponse.of(likesCount));
+    }
+
+    @DeleteMapping("/likes")
+    public ResponseEntity<LikesResponse> unlikeArticle(@PathVariable Long articleId, @AuthenticationPrincipal MemberDto memberDto) {
+        Integer likesCount = likesService.unlikeArticle(articleId, memberDto);
+        return ResponseEntity.ok(LikesResponse.of(likesCount));
     }
 }

--- a/src/main/java/com/isack/syp/likes/LikesRepository.java
+++ b/src/main/java/com/isack/syp/likes/LikesRepository.java
@@ -9,4 +9,6 @@ public interface LikesRepository extends JpaRepository<Likes, Long> {
 
     Optional<Likes> findByMemberIdAndArticleId(Long memberId, Long articleId);
 
+    boolean existsByMemberIdAndArticleId(Long memberId, Long articleId);
+
 }

--- a/src/main/java/com/isack/syp/likes/LikesResponse.java
+++ b/src/main/java/com/isack/syp/likes/LikesResponse.java
@@ -1,0 +1,16 @@
+package com.isack.syp.likes;
+
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class LikesResponse {
+    private Integer likesCount;
+
+    public static LikesResponse of(Integer likesCount) {
+        return new LikesResponse(likesCount);
+    }
+}


### PR DESCRIPTION
# 작업 내용
* API 하나로 좋아요 등록과 삭제를 둘 다 담당했었지만 나누는 것이  restful 하다 생각해서 나누었습니다.
* 프론트에서 좋아요 기능을 구현했습니다.

# 작업 상세
* feat: 좋아요 API 분리
  * 등록 api, 삭제 api 둘로 분리하였습니다.
  * 게시글상세 응답에 좋아요 유무와 개수도 포함하게 하였습니다.
* feat: 좋아요 기능 프론트 구현
* feat: 더미데이터 수정
  * `article_item` 테이블에도 더미데이터를 넣도록 하였습니다.

# 관련 이슈
* This closes #75 