### PR TITLE
feat: 플레이리스트 관련 프론트 구현

### DIFF
--- a/front/src/App.vue
+++ b/front/src/App.vue
@@ -19,22 +19,4 @@ import Content from '@/components/Content.vue'
   </div>
 </template>
 
-<style scoped>
-body {
-  font-family:
-    Pretendard,
-    -apple-system,
-    BlinkMacSystemFont,
-    system-ui,
-    Roboto,
-    'Helvetica Neue',
-    'Segoe UI',
-    'Apple SD Gothic Neo',
-    'Noto Sans KR',
-    'Malgun Gothic',
-    'Apple Color Emoji',
-    'Segoe UI Emoji',
-    'Segoe UI Symbol',
-    sans-serif;
-}
-</style>
+<style scoped></style>

--- a/front/src/components/Header.vue
+++ b/front/src/components/Header.vue
@@ -13,7 +13,7 @@
       <el-menu-item v-if="!isLoggedIn" index="/login">Login</el-menu-item>
       <el-sub-menu v-if="isLoggedIn">
         <template #title>My Page</template>
-        <el-menu-item index="/My Playlist">My Playlist</el-menu-item>
+        <el-menu-item index="/my-playlist">My Playlist</el-menu-item>
         <el-menu-item index="/likes">Likes</el-menu-item>
         <el-menu-item index="/setting">Setting</el-menu-item>
         <el-menu-item v-if="isLoggedIn" @click="logout()">Logout</el-menu-item>

--- a/front/src/entity/article/Article.ts
+++ b/front/src/entity/article/Article.ts
@@ -8,13 +8,13 @@ export default class Article {
   public createdBy = ''
   public createdAt = ''
   public commentCount = 0
-  public item: Item[] = []
+  public items: Item[] = []
 
   constructor(data?: Partial<Article>) {
     if (data) {
       Object.assign(this, data)
       if ((data as any).itemDtoList) {
-        this.item = (data as any).itemDtoList.map((item: any) => new Item(item))
+        this.items = (data as any).itemDtoList.map((item: any) => new Item(item))
       }
     }
   }

--- a/front/src/entity/playlist/Playlist.ts
+++ b/front/src/entity/playlist/Playlist.ts
@@ -1,0 +1,18 @@
+import Item from '@/entity/article/Item'
+
+export default class Playlist {
+  public id = 0
+  public title = ''
+  public createdAt = ''
+  public createdBy = ''
+  public items: Item[] = []
+
+  constructor(data?: Partial<Playlist>) {
+    if (data) {
+      Object.assign(this, data)
+      if ((data as any).items) {
+        this.items = (data as any).items.map((item: any) => new Item(item))
+      }
+    }
+  }
+}

--- a/front/src/main.ts
+++ b/front/src/main.ts
@@ -15,6 +15,8 @@ import 'element-plus/dist/index.css'
 import 'bootstrap/dist/css/bootstrap.css'
 import axios from 'axios'
 
+import './styles/global.css'
+
 const app = createApp(App)
 
 app.use(ElementPlus)

--- a/front/src/router/index.ts
+++ b/front/src/router/index.ts
@@ -5,6 +5,7 @@ import LoginView from '@/views/LoginView.vue'
 import ReadView from '@/views/ReadView.vue'
 import AllView from '@/views/AllView.vue'
 import UpdateView from '@/views/UpdateView.vue'
+import MyPlaylistView from '@/views/MyPlaylistView.vue'
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -40,6 +41,11 @@ const router = createRouter({
       path: '/all',
       name: 'all',
       component: AllView
+    },
+    {
+      path: '/my-playlist',
+      name: 'myPlaylist',
+      component: MyPlaylistView
     }
     // {
     //   path: '/about',

--- a/front/src/styles/global.css
+++ b/front/src/styles/global.css
@@ -1,0 +1,21 @@
+body {
+    font-family:
+            Pretendard,
+            -apple-system,
+            BlinkMacSystemFont,
+            system-ui,
+            Roboto,
+            'Helvetica Neue',
+            'Segoe UI',
+            'Apple SD Gothic Neo',
+            'Noto Sans KR',
+            'Malgun Gothic',
+            'Apple Color Emoji',
+            'Segoe UI Emoji',
+            'Segoe UI Symbol',
+            sans-serif;
+    background-color: #f0f0f0; /* 원하는 배경색 */
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}

--- a/front/src/views/MyPlaylistView.vue
+++ b/front/src/views/MyPlaylistView.vue
@@ -1,0 +1,66 @@
+<script setup lang="ts">
+import { onMounted, ref } from 'vue'
+import axios from 'axios'
+import Playlist from '@/entity/playlist/Playlist'
+
+const myPlaylists = ref<Playlist[]>([])
+
+const getMyPlaylist = () => {
+  axios.get('/api/playlists/me').then((response) => {
+    myPlaylists.value = response.data.playlistResponses
+  })
+}
+
+onMounted(() => {
+  getMyPlaylist()
+})
+</script>
+<template>
+  <div class="row">
+    <div
+      class="align-items-center border rounded-5 bg-white mb-3"
+      v-for="playlist in myPlaylists"
+      :key="playlist.id"
+    >
+      <div class="row playlist-title">
+        <div class="col-4 text-center">{{ playlist.title }}</div>
+        <div class="col-8 text-end">바로가기</div>
+      </div>
+      <div class="row">
+        <el-carousel :interval="5000" trigger="click" type="card" height="300px">
+          <el-carousel-item v-for="item in playlist.items" :key="playlist.id">
+            <div class="carousel-content">
+              <el-image class="carousel-image" :src="item.thumbnailUrl" style="width: 26em" />
+              <div class="video-title">{{ item.videoTitle }}</div>
+            </div>
+          </el-carousel-item>
+        </el-carousel>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.carousel-image {
+  display: block;
+  margin: auto;
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
+}
+
+.el-carousel__item {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.video-title {
+  font-size: 1em;
+}
+
+.playlist-title {
+  font-size: 22px;
+  font-weight: bold;
+}
+</style>

--- a/src/main/java/com/isack/syp/InitDb.java
+++ b/src/main/java/com/isack/syp/InitDb.java
@@ -44,15 +44,15 @@ public class InitDb {
                 em.persist(article);
                 List<Item> items = new ArrayList<>();
                 Item item1 = Item.of(
-                        "_nXwrx4Qyz8",
+                        "_nXwrx4Qyz8" + i + j,
                         "고양이와 Iwamizu의 Lofi Jazz Piano • 공부할때, 집중할때, 코딩할때 • 3 hours",
                         "https://i.ytimg.com/vi/_nXwrx4Qyz8/mqdefault.jpg");
                 Item item2 = Item.of(
-                        "Uyl_KVZpYQ4",
+                        "Uyl_KVZpYQ4" + i + j,
                         "Erikson Jayanto - Farewell (Official Audio)",
                         "https://i.ytimg.com/vi/_nXwrx4Qyz8/mqdefault.jpg");
                 Item item3 = Item.of(
-                        "DIPxnt5vnhU",
+                        "DIPxnt5vnhU" + i + j,
                         "실리카겔 (Silica Gel) - T + Tik Tak Tok (feat. So!YoON!) [MV]",
                         "https://i.ytimg.com/vi/_nXwrx4Qyz8/mqdefault.jpg");
                 items.add(item1);

--- a/src/main/java/com/isack/syp/playlist/PlaylistController.java
+++ b/src/main/java/com/isack/syp/playlist/PlaylistController.java
@@ -38,9 +38,9 @@ public class PlaylistController {
     }
 
     @PostMapping("/{playlistId}")
-    public ResponseEntity<PlaylistResponse> addItem(@RequestBody ItemDto itemDto, @PathVariable Long playlistId, @AuthenticationPrincipal MemberDto memberDto) {
-        PlaylistResponse playlistResponse = playlistService.addItem(itemDto, playlistId, memberDto);
-        return ResponseEntity.ok(playlistResponse);
+    public ResponseEntity<Void> addItem(@RequestBody ItemDto itemDto, @PathVariable Long playlistId, @AuthenticationPrincipal MemberDto memberDto) {
+        playlistService.addItem(itemDto, playlistId, memberDto);
+        return ResponseEntity.noContent().build();
     }
 
     @DeleteMapping("/{playlistId}/{itemId}")


### PR DESCRIPTION
# 작업 내용
* 자신의 플레이리스트에 아이템을 추가하는 기능, `나의 플레이리스트` 화면을 구현했습니다.

# 작업 상세
* feat: 더미데이터 수정
  * db 의 `item` 테이블에 `videoId` 가 중복되게 들어가서 `NonUniqueResultException` 에러가 발생함. 이를 해결하기 위해 `videoId` 를 중복되지 않게 함
* refactor: `PlaylistResponse` -> `Void` 변경
  * 아이템을 추가하는 API 인데 굳이 반환값으로 무언가를 줄 필요가 없다 판단함
* fix: 중복된 아이템일 때 `id` 가 `null` 로 반환되는 문제 해결
* feat: 플레이리스트에 아이템 추가 프론트 구현
* `나의 플레이리스트` 화면 구현

# 관련 이슈
* This closes #77